### PR TITLE
Remove NOOP step

### DIFF
--- a/maven-resolver-named-locks-redisson/src/main/java/org/eclipse/aether/named/redisson/RedissonReadWriteLockNamedLockFactory.java
+++ b/maven-resolver-named-locks-redisson/src/main/java/org/eclipse/aether/named/redisson/RedissonReadWriteLockNamedLockFactory.java
@@ -19,7 +19,7 @@ package org.eclipse.aether.named.redisson;
  * under the License.
  */
 
-import org.eclipse.aether.named.support.AdaptedReadWriteLockNamedLock;
+import org.eclipse.aether.named.support.ReadWriteLockNamedLock;
 import org.eclipse.aether.named.support.NamedLockSupport;
 
 import javax.inject.Named;
@@ -38,12 +38,10 @@ public class RedissonReadWriteLockNamedLockFactory
   @Override
   protected NamedLockSupport createLock( final String name )
   {
-    return new AdaptedReadWriteLockNamedLock(
+    return new ReadWriteLockNamedLock(
             name,
             this,
-            new AdaptedReadWriteLockNamedLock.JVMReadWriteLock(
-                    redissonClient.getReadWriteLock( NAME_PREFIX + name )
-            )
+            redissonClient.getReadWriteLock( NAME_PREFIX + name )
     );
   }
 }

--- a/maven-resolver-named-locks/src/main/java/org/eclipse/aether/named/providers/LocalReadWriteLockNamedLockFactory.java
+++ b/maven-resolver-named-locks/src/main/java/org/eclipse/aether/named/providers/LocalReadWriteLockNamedLockFactory.java
@@ -24,7 +24,7 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
 import javax.inject.Named;
 import javax.inject.Singleton;
 
-import org.eclipse.aether.named.support.AdaptedReadWriteLockNamedLock;
+import org.eclipse.aether.named.support.ReadWriteLockNamedLock;
 import org.eclipse.aether.named.support.NamedLockFactorySupport;
 
 /**
@@ -38,12 +38,12 @@ public class LocalReadWriteLockNamedLockFactory
   public static final String NAME = "rwlock-local";
 
   @Override
-  protected AdaptedReadWriteLockNamedLock createLock( final String name )
+  protected ReadWriteLockNamedLock createLock( final String name )
   {
-    return new AdaptedReadWriteLockNamedLock(
+    return new ReadWriteLockNamedLock(
         name,
         this,
-        new AdaptedReadWriteLockNamedLock.JVMReadWriteLock( new ReentrantReadWriteLock() )
+        new ReentrantReadWriteLock()
     );
   }
 }


### PR DESCRIPTION
Altough JVM iface ReadWriteLock interface does not state
anything about reentrancy, let's assume that locks we use
are reentrant, and remove the NOOP step, instead always apply
given lock-step onto (now reentrant) lock.