### PR TITLE
Move leak warn to factory

### DIFF
--- a/maven-resolver-named-locks/src/main/java/org/eclipse/aether/named/support/NamedLockFactorySupport.java
+++ b/maven-resolver-named-locks/src/main/java/org/eclipse/aether/named/support/NamedLockFactorySupport.java
@@ -86,7 +86,7 @@ public abstract class NamedLockFactorySupport implements NamedLockFactory
             if ( !locks.isEmpty() )
             {
                 // report leak
-                log.warn( "Lock leak, referenced locks still exists {}", locks );
+                log.warn( "Lock leak, referenced locks still exist {}", locks );
             }
         }
         finally
@@ -125,7 +125,8 @@ public abstract class NamedLockFactorySupport implements NamedLockFactory
         }
 
         @Override
-        public String toString() {
+        public String toString()
+        {
             return "[refCount" + referenceCount.get() + ", lock=" + namedLock + "]";
         }
     }

--- a/maven-resolver-named-locks/src/main/java/org/eclipse/aether/named/support/NamedLockFactorySupport.java
+++ b/maven-resolver-named-locks/src/main/java/org/eclipse/aether/named/support/NamedLockFactorySupport.java
@@ -127,7 +127,7 @@ public abstract class NamedLockFactorySupport implements NamedLockFactory
         @Override
         public String toString()
         {
-            return "[refCount" + referenceCount.get() + ", lock=" + namedLock + "]";
+            return "[refCount=" + referenceCount.get() + ", lock=" + namedLock + "]";
         }
     }
 }

--- a/maven-resolver-named-locks/src/main/java/org/eclipse/aether/named/support/NamedLockSupport.java
+++ b/maven-resolver-named-locks/src/main/java/org/eclipse/aether/named/support/NamedLockSupport.java
@@ -51,22 +51,4 @@ public abstract class NamedLockSupport implements NamedLock
     {
         factory.closeLock( this );
     }
-
-    @Override
-    protected void finalize() throws Throwable
-    {
-        try
-        {
-            int refCount = factory.refCount( this );
-            if ( refCount != 0 )
-            {
-                // report leak
-                log.warn( "NamedLock leak: {} references={}", name, refCount );
-            }
-        }
-        finally
-        {
-            super.finalize();
-        }
-    }
 }


### PR DESCRIPTION
As having it in lock makes not really sense, lock is
in map (hard ref) until it reaches 0 refCount when
it is removed.

Still, the warning is needed, as in maven we have
complex classloaders and container hierarchies, so
having a warning is still handy.