### PR TITLE
Make sure we cache the hashCode as it will be called a lot

### DIFF
--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/collect/DataPool.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/collect/DataPool.java
@@ -234,9 +234,11 @@ public final class DataPool {
 
     public static final class DescriptorKey {
         private final Artifact artifact;
+        private final int hashCode;
 
         private DescriptorKey(Artifact artifact) {
             this.artifact = artifact;
+            this.hashCode = buildHashCode();
         }
 
         @Override
@@ -253,6 +255,10 @@ public final class DataPool {
 
         @Override
         public int hashCode() {
+            return hashCode;
+        }
+
+        private int buildHashCode() {
             return Objects.hashCode(artifact);
         }
 


### PR DESCRIPTION
@cstamas this should help make your patch faster. We came to this conclusion in Hibernate Validator after a lot of benchmarking. Whenever you get an object that is very heavily used in HashMaps, it's often worth caching the hashCode.